### PR TITLE
PKG-1212: Updates for v0.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - pip
     - wheel
   run:
-    - python >=3
-    - numpy >=1.17.3
+    - python
+    - numpy
     - scipy >=1.3.2
     - scikit-learn >=1.0.2
     - joblib >=1.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
   imports:
     - imblearn
   commands:
+    - pip check
     - pytest --timeout 300 --verbose --pyargs imblearn
 
 about:
@@ -49,7 +50,7 @@ about:
     techniques commonly used in datasets showing strong between-class imbalance.
     It is compatible with scikit-learn and is part of scikit-learn-contrib
     projects.
-  doc_url: http://imbalanced-learn.org/en/stable/
+  doc_url: https://imbalanced-learn.org/en/stable/
   dev_url: https://github.com/scikit-learn-contrib/imbalanced-learn
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy
     - scipy >=1.3.2
     - scikit-learn >=1.0.2
-    - joblib >=1.1.0
+    - joblib >=1.1.1
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "imbalanced-learn" %}
-{% set version = "0.9.0" %}
-{% set sha256 = "836a4c137cc3c10310d4f6cd5ec34600ff488d7f8c243a997c3f9b551c91d0b2" %}
+{% set version = "0.10.1" %}
+{% set sha256 = "bc7609619ec3c38c442292928239ad3d10b5deb0af8a29c83822b7b57b319f8b" %}
 
 package:
   name: {{ name|lower }}
@@ -17,23 +17,21 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-  build:
-    - python >=3
+  host:
+    - python
     - setuptools
     - pip
-  host:
-    - python >=3
-    - pip
+    - wheel
   run:
     - python >=3
-    - numpy >=1.14.6
-    - scipy >=1.1.0
-    - scikit-learn >=1.0.1
-    - joblib >=0.11
+    - numpy >=1.17.3
+    - scipy >=1.3.2
+    - scikit-learn >=1.0.2
+    - joblib >=1.1.0
 
 test:
   requires:
-    - pytest >=3.3.0
+    - pytest >=5.0.1
     - pytest-timeout
   imports:
     - imblearn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
 
 test:
   requires:
+    - pip
     - pytest >=5.0.1
     - pytest-timeout
   imports:
@@ -50,7 +51,7 @@ about:
     techniques commonly used in datasets showing strong between-class imbalance.
     It is compatible with scikit-learn and is part of scikit-learn-contrib
     projects.
-  doc_url: https://imbalanced-learn.org/en/stable/
+  doc_url: https://imbalanced-learn.org/stable/
   dev_url: https://github.com/scikit-learn-contrib/imbalanced-learn
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 


### PR DESCRIPTION
Jira: https://anaconda.atlassian.net/browse/PKG-1212

I reviewed the [upstream requirements and version constraints](https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/imblearn/_min_dependencies.py#L4-L39), but the upstream maintainers also [maintain the conda-forge recipe](https://github.com/conda-forge/imbalanced-learn-feedstock/blob/main/recipe/meta.yaml#L59) (upon which the changes in this PR are based). I'm inclined to follow their specs, but remove the pinnings for `python` and `numpy` so that the values in our cbc.yaml will be used.