### PR TITLE
Rebuild for Python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   skip: True  # [py<38]
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy
+    - numpy >=1.17.3
     - scipy >=1.3.2
     - scikit-learn >=1.0.2
     - joblib >=1.1.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     - scipy >=1.3.2
     - scikit-learn >=1.0.2
     - joblib >=1.1.1
+  run_constrained:
+    - threadpoolctl >=2.0.0
 
 test:
   requires:


### PR DESCRIPTION
Simple rebuild for Python 3.11. I also adjusted the runtime dependencies to better match the upstream package.