### PR TITLE
add run_constrained on intel-openmp due to openmp issue

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - joblib >=1.1.1
   run_constrained:
     - threadpoolctl >=2.0.0
+    # intel-openmp 2023.1 and llvm-openmp 14.0.6 appear not be compatible
+    # leading to segfault in test_pairwise_distances_reduction.py::test_sqeuclidean_row_norms[42-float64-8-5-100]
     - intel-openmp <2023.1.0  # [osx and x86_64]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - joblib >=1.1.1
   run_constrained:
     - threadpoolctl >=2.0.0
+    - intel-openmp <2023.1.0  # [osx and x86_64]
 
 test:
   requires:


### PR DESCRIPTION
Changes:
- not increasing the build number, as the pervious PR was not uploaded.
- add constraint on intel-openmp version osx-64