### PR TITLE
imbalanced-learn 0.14.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "imbalanced-learn" %}
-{% set version = "0.13.0" %}
+{% set version = "0.14.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name}}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
-  sha256: d4a8d6372086982350d6de1c7e5b1ed5ece9e41bf93043b4d0e9ea1c422a6606
+  sha256: 22b9ba6dbd681a9ec613cd6e08c21d39639fb5ccbf2a3c991f9c36415b70522c
 
 build:
   number: 0
@@ -17,22 +17,21 @@ build:
 requirements:
   host:
     - python
-    - setuptools
+    - setuptools >=71
     - pip
-    - wheel
+    - toml
     - setuptools_scm >=8
   run:
     - python
-    - numpy >=1.24.3,<3
-    - scipy >=1.10.1,<2
-    - scikit-learn >=1.3.2,<2
-    - sklearn-compat >=0.1,<1
+    - numpy >=1.25.2,<3
+    - scipy >=1.11.4,<2
+    - scikit-learn >=1.4.2,<2
     - joblib >=1.1.1,<2
     - threadpoolctl >=2.0.0,<4
   run_constrained:
-    - pandas >=1.5.3,<3
-    - tensorflow >=2.13.1,<3
-    - keras >=3.0.5,<4
+    - pandas >=2.0.3,<3
+    - tensorflow >=2.16.1,<3
+    - keras >=3.3.3,<4
 
 test:
   requires:
@@ -45,12 +44,10 @@ test:
     - imblearn
   commands:
     - pip check
-    # Skipping because README.rst and pyproject.toml deps are misaligned causing failures
-    # test_estimators_compat_sklearn appears to have a bug introduced with latest release of scikit-learn RE: tags
-    - pytest --pyargs imblearn -vv --timeout 300 -k "not (test_min_dependencies_readme or test_estimators_compatibility_sklearn)"
+    - pytest --pyargs imblearn.tests
 
 about:
-  home: https://github.com/scikit-learn-contrib/imbalanced-learn
+  home: https://imbalanced-learn.org
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -60,7 +57,7 @@ about:
     techniques commonly used in datasets showing strong between-class imbalance.
     It is compatible with scikit-learn and is part of scikit-learn-contrib
     projects.
-  doc_url: https://imbalanced-learn.org/stable/
+  doc_url: https://imbalanced-learn.org/stable
   dev_url: https://github.com/scikit-learn-contrib/imbalanced-learn
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - numpy >=1.25.2,<3
     - scipy >=1.11.4,<2
     - scikit-learn >=1.4.2,<2
-    - joblib >=1.1.1,<2
+    - joblib >=1.2.0,<2
     - threadpoolctl >=2.0.0,<4
   run_constrained:
     - pandas >=2.0.3,<3


### PR DESCRIPTION
imbalanced-learn 0.14.0 

**Destination channel:** Defaults

### Links

- [PKG-9375]
- dev_url:        https://github.com/scikit-learn-contrib/imbalanced-learn/tree/0.14.0
- conda_forge:    https://github.com/conda-forge/imbalanced-learn-feedstock
- pypi:           https://pypi.org/project/imbalanced-learn/0.14.0/
- pypi inspector: https://inspector.pypi.io/project/imbalanced-learn/0.14.0/

### Explanation of changes:

- new version number


[PKG-9375]: https://anaconda.atlassian.net/browse/PKG-9375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ